### PR TITLE
fix(public-allocator): allow set flow cap to 0 for a non-listed vault market

### DIFF
--- a/src/public-allocator.ts
+++ b/src/public-allocator.ts
@@ -12,7 +12,8 @@ import {
   Account,
   MarketFlowCapsSet,
   MetaMorpho,
-  MetaMorphoAllocator, MetaMorphoMarket,
+  MetaMorphoAllocator,
+  MetaMorphoMarket,
   MetaMorphoPublicAllocator,
   MetaMorphoPublicAllocatorMarket,
   PublicAllocatorReallocationToEvent,
@@ -238,9 +239,6 @@ export function handleSetFlowCaps(event: SetFlowCaps): void {
   setFlowCapsEvent.save();
 
   for (let i = 0; i < event.params.config.length; i++) {
-
-
-
     const config = event.params.config[i];
 
     const mmMarket = MetaMorphoMarket.load(

--- a/src/public-allocator.ts
+++ b/src/public-allocator.ts
@@ -12,7 +12,7 @@ import {
   Account,
   MarketFlowCapsSet,
   MetaMorpho,
-  MetaMorphoAllocator,
+  MetaMorphoAllocator, MetaMorphoMarket,
   MetaMorphoPublicAllocator,
   MetaMorphoPublicAllocatorMarket,
   PublicAllocatorReallocationToEvent,
@@ -238,7 +238,25 @@ export function handleSetFlowCaps(event: SetFlowCaps): void {
   setFlowCapsEvent.save();
 
   for (let i = 0; i < event.params.config.length; i++) {
+
+
+
     const config = event.params.config[i];
+
+    const mmMarket = MetaMorphoMarket.load(
+      event.params.vault.concat(config.id)
+    );
+
+    if (
+      !mmMarket &&
+      config.caps.maxIn.isZero() &&
+      config.caps.maxOut.isZero()
+    ) {
+      // because of the following line on the PA contract, you can set a flow cap to 0 for a non-listed market
+      // If the mmMarket doesn't exist at all, we just skip the cap configuration
+      // https://github.com/morpho-org/public-allocator/blob/main/src/PublicAllocator.sol#L85
+      continue;
+    }
 
     const paMarket = loadPublicAllocatorMarket(event.params.vault, config.id);
 

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -137,8 +137,8 @@ dataSources:
     name: PublicAllocator
     network: mainnet
     source:
-      address: "0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D"
       abi: PublicAllocator
+      address: "0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D"
       startBlock: 19375099
     mapping:
       kind: ethereum/events


### PR DESCRIPTION

Issue raised by [this Tx](https://basescan.org/tx/0xe5b3ea70e78eb7e6f619fa6580d4995e45b8a90cfb6a70d6f7ec3f7a094fc5c0#eventlog)
